### PR TITLE
use node version - not instrumentation library version

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -116,9 +116,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       'http',
       ['*'],
       moduleExports => {
-        this._diag.debug(
-          `Applying patch for http@${version}`
-        );
+        this._diag.debug(`Applying patch for http@${version}`);
         if (isWrapped(moduleExports.request)) {
           this._unwrap(moduleExports, 'request');
         }
@@ -147,9 +145,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       },
       moduleExports => {
         if (moduleExports === undefined) return;
-        this._diag.debug(
-          `Removing patch for http@${version}`
-        );
+        this._diag.debug(`Removing patch for http@${version}`);
 
         this._unwrap(moduleExports, 'request');
         this._unwrap(moduleExports, 'get');
@@ -164,9 +160,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       'https',
       ['*'],
       moduleExports => {
-        this._diag.debug(
-          `Applying patch for https@${version}`
-        );
+        this._diag.debug(`Applying patch for https@${version}`);
         if (isWrapped(moduleExports.request)) {
           this._unwrap(moduleExports, 'request');
         }
@@ -195,9 +189,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       },
       moduleExports => {
         if (moduleExports === undefined) return;
-        this._diag.debug(
-          `Removing patch for https@${version}`
-        );
+        this._diag.debug(`Removing patch for https@${version}`);
 
         this._unwrap(moduleExports, 'request');
         this._unwrap(moduleExports, 'get');

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -111,12 +111,13 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
   }
 
   private _getHttpInstrumentation() {
+    const version = process.version;
     return new InstrumentationNodeModuleDefinition<Http>(
       'http',
       ['*'],
       moduleExports => {
         this._diag.debug(
-          `Applying patch for http@${this.instrumentationVersion}`
+          `Applying patch for http@${version}`
         );
         if (isWrapped(moduleExports.request)) {
           this._unwrap(moduleExports, 'request');
@@ -147,7 +148,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       moduleExports => {
         if (moduleExports === undefined) return;
         this._diag.debug(
-          `Removing patch for http@${this.instrumentationVersion}`
+          `Removing patch for http@${version}`
         );
 
         this._unwrap(moduleExports, 'request');
@@ -158,12 +159,13 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
   }
 
   private _getHttpsInstrumentation() {
+    const version = process.version;
     return new InstrumentationNodeModuleDefinition<Https>(
       'https',
       ['*'],
       moduleExports => {
         this._diag.debug(
-          `Applying patch for https@${this.instrumentationVersion}`
+          `Applying patch for https@${version}`
         );
         if (isWrapped(moduleExports.request)) {
           this._unwrap(moduleExports, 'request');
@@ -194,7 +196,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       moduleExports => {
         if (moduleExports === undefined) return;
         this._diag.debug(
-          `Removing patch for https@${this.instrumentationVersion}`
+          `Removing patch for https@${version}`
         );
 
         this._unwrap(moduleExports, 'request');


### PR DESCRIPTION
When adding support for ESM, diagnostic logging for http instrumentation showed a version number of `undefined`.

When creating the PR upstream, I changed `this._version` - which pulled in `process.versions.node` using the `HttpInstrumentation` class - to `this.instrumentationVersion`, which pulled in the version of the instrumentation library package. I thought the version was intended to be the OTel instrumentation package version, but it should actually be the http package version. Since http is a node module, it should be using the node version.

This PR swaps out `this.instrumentationVersion` in favor of `version`, setting the version in each private function to ensure it has access to the node version. 

Using the esm example app:

original (before any changes): `@opentelemetry/instrumentation-http Applying patch for http@undefined`

current (with this change): `@opentelemetry/instrumentation-http Applying patch for http@v16.15.0` and `@opentelemetry/instrumentation-http Applying patch for http@v19.8.1` when running with different node versions