### PR TITLE
Ship shimmer types

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -70,6 +70,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
+    "@types/shimmer": "^1.0.2",
     "import-in-the-middle": "^1.3.4",
     "require-in-the-middle": "^6.0.0",
     "semver": "^7.3.2",
@@ -85,7 +86,6 @@
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",
-    "@types/shimmer": "1.0.2",
     "@types/sinon": "10.0.13",
     "@types/webpack-env": "1.16.3",
     "babel-loader": "8.2.3",


### PR DESCRIPTION
## Which problem is this PR solving?

We need to include the types package for `shimmer` since we depend on these types directly.
