### PR TITLE
address PR feedback

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -25,7 +25,7 @@ import {
   Hooked,
 } from './RequireInTheMiddleSingleton';
 import type { HookFn } from 'import-in-the-middle';
-import * as ImportInTheMiddle from 'import-in-the-middle';
+import ESMHook from 'import-in-the-middle';
 import { InstrumentationModuleDefinition } from './types';
 import { diag } from '@opentelemetry/api';
 import type { OnRequireFn } from 'require-in-the-middle';
@@ -248,7 +248,7 @@ export abstract class InstrumentationBase<T = any>
 
     this._warnOnPreloadedModules();
     for (const module of this._modules) {
-      const hookFn: ImportInTheMiddle.HookFn = (exports, name, baseDir) => {
+      const hookFn: HookFn = (exports, name, baseDir) => {
         return this._onRequire<typeof exports>(
           module as unknown as InstrumentationModuleDefinition<typeof exports>,
           exports,
@@ -273,12 +273,11 @@ export abstract class InstrumentationBase<T = any>
         : this._requireInTheMiddleSingleton.register(module.name, onRequire);
 
       this._hooks.push(hook);
-      const esmHook =
-        new (ImportInTheMiddle as unknown as typeof ImportInTheMiddle.default)(
-          [module.name],
-          { internals: false },
-          <HookFn>hookFn
-        );
+      const esmHook = new ESMHook(
+        [module.name],
+        { internals: false },
+        <HookFn>hookFn
+      );
       this._hooks.push(esmHook);
     }
   }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -25,7 +25,7 @@ import {
   Hooked,
 } from './RequireInTheMiddleSingleton';
 import type { HookFn } from 'import-in-the-middle';
-import ESMHook from 'import-in-the-middle';
+import * as ImportInTheMiddle from 'import-in-the-middle';
 import { InstrumentationModuleDefinition } from './types';
 import { diag } from '@opentelemetry/api';
 import type { OnRequireFn } from 'require-in-the-middle';
@@ -266,11 +266,12 @@ export abstract class InstrumentationBase<T = any>
         : this._requireInTheMiddleSingleton.register(module.name, onRequire);
 
       this._hooks.push(hook);
-      const esmHook = new (ESMHook as unknown as typeof ESMHook)(
-        [module.name],
-        { internals: false },
-        <HookFn>hookFn
-      );
+      const esmHook =
+        new (ImportInTheMiddle as unknown as typeof ImportInTheMiddle.default)(
+          [module.name],
+          { internals: false },
+          <HookFn>hookFn
+        );
       this._hooks.push(esmHook);
     }
   }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -16,15 +16,15 @@
 
 import * as types from '../../types';
 import * as path from 'path';
-import * as util from 'util';
+import { types as utilTypes } from 'util';
 import { satisfies } from 'semver';
-import * as shimmer from 'shimmer';
+import { wrap, unwrap, massWrap, massUnwrap } from 'shimmer';
 import { InstrumentationAbstract } from '../../instrumentation';
 import {
   RequireInTheMiddleSingleton,
   Hooked,
 } from './RequireInTheMiddleSingleton';
-import { HookFn } from 'import-in-the-middle';
+import type { HookFn } from 'import-in-the-middle';
 import * as ImportInTheMiddle from 'import-in-the-middle';
 import { InstrumentationModuleDefinition } from './types';
 import { diag } from '@opentelemetry/api';
@@ -72,44 +72,36 @@ export abstract class InstrumentationBase<T = any>
     }
   }
 
-  protected override _wrap: typeof shimmer.wrap = (
-    moduleExports,
-    name,
-    wrapper
-  ) => {
-    if (!util.types.isProxy(moduleExports)) {
-      return shimmer.wrap(moduleExports, name, wrapper);
+  protected override _wrap: typeof wrap = (moduleExports, name, wrapper) => {
+    if (!utilTypes.isProxy(moduleExports)) {
+      return wrap(moduleExports, name, wrapper);
     } else {
       return this._wrapEsm(moduleExports, name, wrapper);
     }
   };
 
-  protected override _unwrap: typeof shimmer.unwrap = (moduleExports, name) => {
-    if (!util.types.isProxy(moduleExports)) {
-      return shimmer.unwrap(moduleExports, name);
+  protected override _unwrap: typeof unwrap = (moduleExports, name) => {
+    if (!utilTypes.isProxy(moduleExports)) {
+      return unwrap(moduleExports, name);
     } else {
       return this._unwrapEsm(moduleExports, name);
     }
   };
 
-  private _wrapEsm: typeof shimmer.wrap = (moduleExports, name, wrapper) => {
-    const wrapped = shimmer.wrap(
-      Object.assign({}, moduleExports),
-      name,
-      wrapper
-    );
+  private _wrapEsm: typeof wrap = (moduleExports, name, wrapper) => {
+    const wrapped = wrap(Object.assign({}, moduleExports), name, wrapper);
     Object.defineProperty(moduleExports, name, {
       value: wrapped,
     });
   };
 
-  private _unwrapEsm: typeof shimmer.unwrap = (moduleExports, name) => {
+  private _unwrapEsm: typeof unwrap = (moduleExports, name) => {
     Object.defineProperty(moduleExports, name, {
       value: moduleExports[name],
     });
   };
 
-  protected override _massWrap: typeof shimmer.massWrap = (
+  protected override _massWrap: typeof massWrap = (
     moduleExportsArray,
     names,
     wrapper
@@ -133,7 +125,7 @@ export abstract class InstrumentationBase<T = any>
     });
   };
 
-  protected override _massUnwrap: typeof shimmer.massUnwrap = (
+  protected override _massUnwrap: typeof massUnwrap = (
     moduleExportsArray,
     names
   ) => {

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -266,7 +266,7 @@ export abstract class InstrumentationBase<T = any>
         : this._requireInTheMiddleSingleton.register(module.name, onRequire);
 
       this._hooks.push(hook);
-      const esmHook = new ESMHook(
+      const esmHook = new (ESMHook as unknown as typeof ESMHook)(
         [module.name],
         { internals: false },
         <HookFn>hookFn

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -76,7 +76,11 @@ export abstract class InstrumentationBase<T = any>
     if (!utilTypes.isProxy(moduleExports)) {
       return wrap(moduleExports, name, wrapper);
     } else {
-      return this._wrapEsm(moduleExports, name, wrapper);
+      const wrapped = wrap(Object.assign({}, moduleExports), name, wrapper);
+
+      return Object.defineProperty(moduleExports, name, {
+        value: wrapped,
+      });
     }
   };
 
@@ -84,21 +88,10 @@ export abstract class InstrumentationBase<T = any>
     if (!utilTypes.isProxy(moduleExports)) {
       return unwrap(moduleExports, name);
     } else {
-      return this._unwrapEsm(moduleExports, name);
+      return Object.defineProperty(moduleExports, name, {
+        value: moduleExports[name],
+      });
     }
-  };
-
-  private _wrapEsm: typeof wrap = (moduleExports, name, wrapper) => {
-    const wrapped = wrap(Object.assign({}, moduleExports), name, wrapper);
-    Object.defineProperty(moduleExports, name, {
-      value: wrapped,
-    });
-  };
-
-  private _unwrapEsm: typeof unwrap = (moduleExports, name) => {
-    Object.defineProperty(moduleExports, name, {
-      value: moduleExports[name],
-    });
   };
 
   protected override _massWrap: typeof massWrap = (


### PR DESCRIPTION
## Which problem is this PR solving?
Addresses comments about using [* imports](https://github.com/open-telemetry/opentelemetry-js/pull/3698#discussion_r1183919587) and [inlining wrapEsm / unwrapEsm functions](https://github.com/open-telemetry/opentelemetry-js/pull/3698#discussion_r1183926426).

## Short description of the changes
- Avoided using the `import * as X` pattern since it is not ESM friendly
- Inlined the private `_wrapEsm` & `_unwrapEsm` functions

